### PR TITLE
Fix for reference assemblies not working correctly

### DIFF
--- a/src/TextTemplating/TemplatingEngine.cs
+++ b/src/TextTemplating/TemplatingEngine.cs
@@ -199,6 +199,7 @@ namespace T5.TextTemplating
             var options =
                 ScriptOptions.Default
                              .AddReferences(typeof(TextTransformation).Assembly)
+                             .AddReferences(pars.ReferencedAssemblies.Cast<string>())
                              .AddImports(from CodeNamespaceImport import in ns.Imports select import.Namespace);
 
             var results = new CompilerResults(pars.TempFiles);

--- a/tests/GenerationTests.cs
+++ b/tests/GenerationTests.cs
@@ -64,14 +64,15 @@ namespace T5.TextTemplating.Tests
             gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (System.Linq.Enumerable).Assembly.Location));
             gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (JsonConvert).Assembly.Location));
             
-            gen.ProcessTemplate (null, @"<#@ assembly name=""System.dll"" #>
-<#@ assembly name=""System.Core.dll"" #>
-<#@ assembly name=""Newtonsoft.Json.dll"" #>
-<#@ import namespace=""Newtonsoft.Json"" #>
-<#
-    var content = JsonConvert.SerializeObject(""hello"");
-#>
-", ref tmp, out tmp);
+            gen.ProcessTemplate (null, @"
+                <#@ assembly name=""System.dll"" #>
+                <#@ assembly name=""System.Core.dll"" #>
+                <#@ assembly name=""Newtonsoft.Json.dll"" #>
+                <#@ import namespace=""Newtonsoft.Json"" #>
+                <#
+                    var content = JsonConvert.SerializeObject(""hello"");
+                #>
+                ", ref tmp, out tmp);
             
             Assert.AreEqual (0, gen.Errors.Count, "ImportReferencesTest");
         }

--- a/tests/GenerationTests.cs
+++ b/tests/GenerationTests.cs
@@ -63,7 +63,7 @@ namespace T5.TextTemplating.Tests
             gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (Uri).Assembly.Location));
             gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (System.Linq.Enumerable).Assembly.Location));
             gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (JsonConvert).Assembly.Location));
-            
+
             gen.ProcessTemplate (null, @"
                 <#@ assembly name=""System.dll"" #>
                 <#@ assembly name=""System.Core.dll"" #>
@@ -73,10 +73,10 @@ namespace T5.TextTemplating.Tests
                     var content = JsonConvert.SerializeObject(""hello"");
                 #>
                 ", ref tmp, out tmp);
-            
+
             Assert.AreEqual (0, gen.Errors.Count, "ImportReferencesTest");
         }
-        
+
         [Test]
         public void Generate ()
         {

--- a/tests/GenerationTests.cs
+++ b/tests/GenerationTests.cs
@@ -74,7 +74,7 @@ namespace T5.TextTemplating.Tests
                 #>
                 ", ref tmp, out tmp);
 
-            Assert.AreEqual (0, gen.Errors.Count, "ImportReferencesTest");
+            Assert.AreEqual (0, gen.Errors.Count, nameof(ImportLocalDirectoryReferencesTest));
         }
 
         [Test]

--- a/tests/GenerationTests.cs
+++ b/tests/GenerationTests.cs
@@ -25,15 +25,13 @@
 // THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using Microsoft.VisualStudio.TextTemplating;
+using Newtonsoft.Json;
 
 namespace T5.TextTemplating.Tests
 {
-
-
     [TestFixture]
     public class GenerationTests
     {
@@ -57,6 +55,27 @@ namespace T5.TextTemplating.Tests
             Assert.AreEqual (0, gen.Errors.Count, "ImportReferencesTest");
         }
 
+        [Test]
+        public void ImportLocalDirectoryReferencesTest ()
+        {
+            var gen = new TemplateGenerator ();
+            string tmp = null;
+            gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (Uri).Assembly.Location));
+            gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (System.Linq.Enumerable).Assembly.Location));
+            gen.ReferencePaths.Add (Path.GetDirectoryName (typeof (JsonConvert).Assembly.Location));
+            
+            gen.ProcessTemplate (null, @"<#@ assembly name=""System.dll"" #>
+<#@ assembly name=""System.Core.dll"" #>
+<#@ assembly name=""Newtonsoft.Json.dll"" #>
+<#@ import namespace=""Newtonsoft.Json"" #>
+<#
+    var content = JsonConvert.SerializeObject(""hello"");
+#>
+", ref tmp, out tmp);
+            
+            Assert.AreEqual (0, gen.Errors.Count, "ImportReferencesTest");
+        }
+        
         [Test]
         public void Generate ()
         {


### PR DESCRIPTION
Today while attempting to using T5 for the first time, I found that referencing 3rd party assemblies like `Newtonsoft.Json` were not working.

It would fail to compile because it did not recognize the types from the assembly.

Upon further investigation I found that the references were not being included correctly when compiling with CSharpScript.

This PR should reproduce the issue and fix it.