### PR TITLE
Add support for .NET Core 2.1 Global Tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
 dist: trusty
 sudo: required
-dotnet: 2.0.0
+dotnet: 2.1.300
 env:
   - CONFIGURATION=Debug
   - CONFIGURATION=Release

--- a/src/TextTransform/TextTransform.csproj
+++ b/src/TextTransform/TextTransform.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <AssemblyName>dotnet-tt</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <VersionPrefix>1.1.0</VersionPrefix>
     <LangVersion>7.1</LangVersion>
     <PackageId>T5.TextTransform.Tool</PackageId>
-    <PackageType>DotNetCliTool</PackageType>
+    <PackAsTool>true</PackAsTool>
     <Description>T4 text transformation tool for dotnet CLI.</Description>
     <Authors>Atif Aziz;Mikayla Hutchinson</Authors>
     <Owners>Atif Aziz</Owners>


### PR DESCRIPTION
Following instructions on https://natemcmaster.com/blog/2018/05/12/dotnet-global-tools/

Fixes #3

I’m not sure that compatibility with .NET Core 2.0 can be maintained. When trying to pack with `netcoreapp2.0` target framework, we get this error:
> /usr/local/share/dotnet/sdk/2.1.300/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackTool.targets(45,5): error : DotnetTool does not support target framework lower than netcoreapp2.1. [~/Projects/t5/src/TextTransform/TextTransform.csproj]